### PR TITLE
client call to load recent loves

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.json:json:20150729'
+    testCompile 'org.mockito:mockito-core:1.10.19'
 
     compile 'com.android.support:appcompat-v7:23.1.0'
     compile 'com.loopj.android:android-async-http:1.4.9'

--- a/app/src/androidTest/java/org/ometa/lovemonster/service/LoveMonsterClientIntegrationTest.java
+++ b/app/src/androidTest/java/org/ometa/lovemonster/service/LoveMonsterClientIntegrationTest.java
@@ -13,7 +13,7 @@ public class LoveMonsterClientIntegrationTest extends AndroidTestCase {
     public void testGetRecentLoves() {
         final List<Love> retrievedLoves = new ArrayList<>();
 
-        LoveMonsterClient.getInstance().retrieveRecentLoves(1, new LoveMonsterClient.LoveListResponseHandler() {
+        LoveMonsterClient.getInstance().retrieveRecentLoves(new LoveMonsterClient.LoveListResponseHandler() {
             @Override
             public void onSuccess(@NonNull List<Love> loves, int totalPages) {
                 retrievedLoves.addAll(loves);
@@ -23,7 +23,7 @@ public class LoveMonsterClientIntegrationTest extends AndroidTestCase {
             public void onFail() {
                 fail("the get recent loves request failed");
             }
-        });
+        }, 1);
 
         assertFalse("should have retrieved loves", retrievedLoves.isEmpty());
 

--- a/app/src/androidTest/java/org/ometa/lovemonster/service/LoveMonsterClientIntegrationTest.java
+++ b/app/src/androidTest/java/org/ometa/lovemonster/service/LoveMonsterClientIntegrationTest.java
@@ -1,0 +1,39 @@
+package org.ometa.lovemonster.service;
+
+import android.support.annotation.NonNull;
+import android.test.AndroidTestCase;
+
+import org.ometa.lovemonster.models.Love;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LoveMonsterClientIntegrationTest extends AndroidTestCase {
+
+    public void testGetRecentLoves() {
+        final List<Love> retrievedLoves = new ArrayList<>();
+
+        LoveMonsterClient.getInstance().retrieveRecentLoves(1, new LoveMonsterClient.LoveListResponseHandler() {
+            @Override
+            public void onSuccess(@NonNull List<Love> loves) {
+                retrievedLoves.addAll(loves);
+            }
+
+            @Override
+            public void onFail() {
+                fail("the get recent loves request failed");
+            }
+        });
+
+        assertFalse("should have retrieved loves", retrievedLoves.isEmpty());
+
+        final Love firstLove = retrievedLoves.get(0);
+        assertNotNull("should set the reason", firstLove.reason);
+        assertNotNull("should set the message", firstLove.message);
+        assertNotNull("should set created at", firstLove.createdAt);
+        assertNotNull("should set lovee email", firstLove.lovee.email);
+        assertNotNull("should set lovee username", firstLove.lovee.username);
+        assertNotNull("should set lover email", firstLove.lover.email);
+        assertNotNull("should set lover username", firstLove.lover.username);
+    }
+}

--- a/app/src/androidTest/java/org/ometa/lovemonster/service/LoveMonsterClientIntegrationTest.java
+++ b/app/src/androidTest/java/org/ometa/lovemonster/service/LoveMonsterClientIntegrationTest.java
@@ -15,7 +15,7 @@ public class LoveMonsterClientIntegrationTest extends AndroidTestCase {
 
         LoveMonsterClient.getInstance().retrieveRecentLoves(1, new LoveMonsterClient.LoveListResponseHandler() {
             @Override
-            public void onSuccess(@NonNull List<Love> loves) {
+            public void onSuccess(@NonNull List<Love> loves, int totalPages) {
                 retrievedLoves.addAll(loves);
             }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.ometa.lovemonster" >
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/org/ometa/lovemonster/Logger.java
+++ b/app/src/main/java/org/ometa/lovemonster/Logger.java
@@ -1,0 +1,71 @@
+package org.ometa.lovemonster;
+
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import cz.msebera.android.httpclient.annotation.ThreadSafe;
+
+
+/**
+ * Provides a thin wrapper over the logging functionality in Android.
+ */
+@ThreadSafe
+public class Logger {
+
+    /**
+     * Used to enable/disable debug logging.  Set to false to disable logging.
+     */
+    public static boolean isDebugEnabled = true;
+
+    /**
+     * The tag to use on logging messages.
+     */
+    protected final String tag;
+
+    /**
+     * Constructs a new logger to be used inside the specified class.
+     *
+     * @param loggedClass
+     *      the class in which logging will occur
+     */
+    public Logger(@NonNull final Class loggedClass) {
+        this.tag = loggedClass.getSimpleName();
+    }
+
+
+    /**
+     * Logs the message at DEBUG level.
+     *
+     * @param message
+     *      the message to log
+     */
+    public void debug(final String message) {
+        debug(message, null);
+    }
+
+    /**
+     * Logs the message and throwable at DEBUG level.
+     *
+     * @param message
+     *      the message to log
+     * @param throwable
+     *      the throwable to log
+     */
+    public void debug(String message, final Throwable throwable) {
+        if (!isDebugEnabled) {
+            return;
+        }
+
+        if (throwable != null) {
+            message = new StringBuilder(message)
+                    .append(" throwableClass=")
+                    .append(throwable.getClass().getSimpleName())
+                    .append(" throwableMessage=")
+                    .append(throwable.getMessage())
+                    .toString();
+        }
+
+        Log.d(tag, message);
+    }
+
+}

--- a/app/src/main/java/org/ometa/lovemonster/service/LoveMonsterClient.java
+++ b/app/src/main/java/org/ometa/lovemonster/service/LoveMonsterClient.java
@@ -144,7 +144,7 @@ public class LoveMonsterClient {
         final String url = buildUrl("api/v1/loves");
 
         final RequestParams params = new RequestParams();
-        params.put("clientId", "androidclient");
+        params.put("clientId", "androidapp");
         params.put("page", page);
         if (userId >= 0) {
             params.put("user_id", userId);

--- a/app/src/main/java/org/ometa/lovemonster/service/LoveMonsterClient.java
+++ b/app/src/main/java/org/ometa/lovemonster/service/LoveMonsterClient.java
@@ -41,7 +41,7 @@ public class LoveMonsterClient {
          * @param loves
          *      the resulting loves
          */
-        void onSuccess(@NonNull List<Love> loves);
+        void onSuccess(@NonNull List<Love> loves, int totalPages);
 
         /**
          * Handler when a request fails.
@@ -137,14 +137,18 @@ public class LoveMonsterClient {
                 @Override
                 public void onSuccess(final int statusCode, final Header[] headers, final JSONObject response) {
                     final String responseBody;
+                    final int totalPages;
+
                     if (response == null) {
                         responseBody = "null";
+                        totalPages = 0;
                     } else {
                         responseBody = response.toString();
+                        totalPages = response.optInt("pages", 0);
                     }
 
                     logger.debug("method=retrieveRecentLoves url=" + url + " handler=onSuccess statusCode=" + statusCode + " response=" + responseBody);
-                    loveListResponseHandler.onSuccess(responseParser.parseLoveList(response));
+                    loveListResponseHandler.onSuccess(responseParser.parseLoveList(response), totalPages);
                 }
 
                 @Override

--- a/app/src/main/java/org/ometa/lovemonster/service/LoveMonsterClient.java
+++ b/app/src/main/java/org/ometa/lovemonster/service/LoveMonsterClient.java
@@ -1,0 +1,180 @@
+package org.ometa.lovemonster.service;
+
+import android.support.annotation.NonNull;
+
+import com.loopj.android.http.AsyncHttpClient;
+import com.loopj.android.http.JsonHttpResponseHandler;
+import com.loopj.android.http.RequestParams;
+
+import org.json.JSONObject;
+import org.ometa.lovemonster.Logger;
+import org.ometa.lovemonster.models.Love;
+
+import java.util.List;
+
+import cz.msebera.android.httpclient.Header;
+import cz.msebera.android.httpclient.annotation.NotThreadSafe;
+
+/**
+ * Client which makes requests to the Love Monster web service. For normal usage, this class is
+ * intended to be used by using the singleton method {@link LoveMonsterClient#getInstance()} to
+ * return a singleton instance. **N.B.** This singleton is not threadsafe due to dependencies on
+ * {@link AsyncHttpClient}.
+ *
+ * {@code
+ *      final LoveMonsterClient client = LoveMonsterClient.getInstance();
+ *      client.retrieveRecentLoves(new LoveListResponseHandler() {... });
+ * }
+ *
+ */
+@NotThreadSafe
+public class LoveMonsterClient {
+
+    /**
+     * Handler for response callbacks from the {@link LoveMonsterClient} for calls which retrieve loves.
+     */
+    public interface LoveListResponseHandler {
+        /**
+         * Invoked when the request successfully completes.  The passed loves may be empty, but cannot
+         * be null.
+         *
+         * @param loves
+         *      the resulting loves
+         */
+        void onSuccess(@NonNull List<Love> loves);
+
+        /**
+         * Handler when a request fails.
+         */
+        void onFail();
+    }
+
+    /**
+     * The singleton instance for this client. Because of {@link AsyncHttpClient}, this instance
+     * is *NOT* threadsafe.
+     */
+    private static final LoveMonsterClient singletonInstance = new LoveMonsterClient();
+
+    /**
+     * Logger used by this class.
+     */
+    private static final Logger logger = new Logger(LoveMonsterClient.class);
+
+    /**
+     * Returns the singleton {@code LoveMonsterClient} instance.  Because of {@link AsyncHttpClient}, this
+     * instance is *NOT* threadsafe.
+     *
+     * @return
+     *      the singleton {@code LoveMonsterClient}
+     */
+    public static LoveMonsterClient getInstance() {
+        return singletonInstance;
+    }
+
+    /**
+     * The parser used to convert responses from the server into model objects.
+     */
+    @NonNull
+    private final ResponseParser responseParser;
+
+    /**
+     * The client used to make asynchronous http requests.
+     */
+    @NonNull
+    private final AsyncHttpClient asyncHttpClient;
+
+    /**
+     * Private constructor used to implement the singleton. Purposely not made protected to avoid
+     * breaking the singleton.
+     * Defaults to use newly instantiated {@link ResponseParser} and {@link AsyncHttpClient} objects.
+     */
+    private LoveMonsterClient() {
+            this(new ResponseParser(), new AsyncHttpClient());
+    }
+
+    /**
+     * Protected constructor used to create an instance. Is protected scope to allow overriding and
+     * easier unit testing.
+     *
+     * @param responseParser
+     *      the response parser to use to parse requests
+     * @param asyncHttpClient
+     *      the http client used to make requests
+     * @throws IllegalArgumentException
+     *      if {@code responseParser} or {@code asyncHttpClient} are {@code null}
+     */
+    protected LoveMonsterClient(@NonNull final ResponseParser responseParser, @NonNull final AsyncHttpClient asyncHttpClient) throws IllegalArgumentException {
+        if (responseParser == null) {
+            throw new IllegalArgumentException("argument `responseParser` cannot be null");
+        }
+        if (asyncHttpClient == null) {
+            throw new IllegalArgumentException("argument `asyncHttpClient` cannot be null");
+        }
+
+        this.responseParser = responseParser;
+        this.asyncHttpClient = asyncHttpClient;
+    }
+
+    /**
+     * Retrieves recent loves asynchronously. Takes a {@link LoveListResponseHandler} which will be
+     * invoked on response completion.
+     *
+     * @param page
+     *      the page of results to send
+     * @param loveListResponseHandler
+     *      the response handler to use on response completion
+     */
+    public void retrieveRecentLoves(@NonNull final int page, @NonNull final LoveListResponseHandler loveListResponseHandler) {
+        final String url = buildUrl("api/v1/loves");
+        logger.debug("method=retrieveRecentLoves url=" + url);
+
+        final RequestParams params = new RequestParams();
+        params.put("clientId", "androidclient");
+        params.put("page", page);
+
+        try {
+            asyncHttpClient.get(url, params, new JsonHttpResponseHandler() {
+                @Override
+                public void onSuccess(final int statusCode, final Header[] headers, final JSONObject response) {
+                    final String responseBody;
+                    if (response == null) {
+                        responseBody = "null";
+                    } else {
+                        responseBody = response.toString();
+                    }
+
+                    logger.debug("method=retrieveRecentLoves url=" + url + " handler=onSuccess statusCode=" + statusCode + " response=" + responseBody);
+                    loveListResponseHandler.onSuccess(responseParser.parseLoveList(response));
+                }
+
+                @Override
+                public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONObject errorResponse) {
+                    final String responseBody;
+                    if (errorResponse == null) {
+                        responseBody = "null";
+                    } else {
+                        responseBody = errorResponse.toString();
+                    }
+
+                    logger.debug("method=retrieveRecentLoves url=" + url + "  handler=onFailure statusCode=" + statusCode + " response=" + responseBody, throwable);
+                    loveListResponseHandler.onFail();
+                }
+            });
+        } catch (final Exception e){
+            logger.debug("method=retrieveRecentLoves url=" + url, e);
+            loveListResponseHandler.onFail();
+        }
+    }
+
+    /**
+     * Builds the full url from the specified path.
+     *
+     * @param path
+     *      the path for the url
+     * @return
+     *      the full url
+     */
+    private String buildUrl(final String path) {
+        return "http://love.snc1/" + path;
+    }
+}

--- a/app/src/main/java/org/ometa/lovemonster/service/LoveMonsterClient.java
+++ b/app/src/main/java/org/ometa/lovemonster/service/LoveMonsterClient.java
@@ -119,12 +119,12 @@ public class LoveMonsterClient {
      * Retrieves recent loves asynchronously. Takes a {@link LoveListResponseHandler} which will be
      * invoked on response completion.
      *
-     * @param page
-     *      the page of results to send
      * @param loveListResponseHandler
      *      the response handler to use on response completion
+     * @param page
+     *      the page of results to send
      */
-    public void retrieveRecentLoves(@NonNull final int page, @NonNull final LoveListResponseHandler loveListResponseHandler) {
+    public void retrieveRecentLoves(@NonNull final LoveListResponseHandler loveListResponseHandler, @NonNull final int page) {
         final String url = buildUrl("api/v1/loves");
         logger.debug("method=retrieveRecentLoves url=" + url);
 

--- a/app/src/main/java/org/ometa/lovemonster/service/LoveMonsterClient.java
+++ b/app/src/main/java/org/ometa/lovemonster/service/LoveMonsterClient.java
@@ -1,6 +1,7 @@
 package org.ometa.lovemonster.service;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.loopj.android.http.AsyncHttpClient;
 import com.loopj.android.http.JsonHttpResponseHandler;
@@ -124,13 +125,32 @@ public class LoveMonsterClient {
      * @param page
      *      the page of results to send
      */
-    public void retrieveRecentLoves(@NonNull final LoveListResponseHandler loveListResponseHandler, @NonNull final int page) {
+    public void retrieveRecentLoves(@NonNull final LoveListResponseHandler loveListResponseHandler, final int page) {
+        retrieveRecentLoves(loveListResponseHandler, page, -1);
+    }
+
+    /**
+     * Retrieves recent loves asynchronously. Takes a {@link LoveListResponseHandler} which will be
+     * invoked on response completion.
+     *
+     * @param loveListResponseHandler
+     *      the response handler to use on response completion
+     * @param page
+     *      the page of results to send
+     * @param userId
+     *      the id of the user to filter results on. passing any non-positive number will cause this value to be ignored
+     */
+    public void retrieveRecentLoves(@NonNull final LoveListResponseHandler loveListResponseHandler, final int page, final int userId) {
         final String url = buildUrl("api/v1/loves");
-        logger.debug("method=retrieveRecentLoves url=" + url);
 
         final RequestParams params = new RequestParams();
         params.put("clientId", "androidclient");
         params.put("page", page);
+        if (userId >= 0) {
+            params.put("user_id", userId);
+        }
+
+        logger.debug("method=retrieveRecentLoves url=" + url + " params=" + params.toString());
 
         try {
             asyncHttpClient.get(url, params, new JsonHttpResponseHandler() {

--- a/app/src/test/java/org/ometa/lovemonster/service/LoveMonsterClientTest.java
+++ b/app/src/test/java/org/ometa/lovemonster/service/LoveMonsterClientTest.java
@@ -53,7 +53,7 @@ public class LoveMonsterClientTest {
         verify(mockAsyncHttpClient).get(eq("http://love.snc1/api/v1/loves"), requestParamsCaptor.capture(), any(JsonHttpResponseHandler.class));
 
         final Map<String, String> requestParams = parseParams(requestParamsCaptor.getValue());
-        assertEquals("should set client id param", requestParams.get("clientId"), "androidclient");
+        assertEquals("should set client id param", requestParams.get("clientId"), "androidapp");
         assertEquals("should set page param", requestParams.get("page"), "77");
         assertEquals("should set user_id param", requestParams.get("user_id"), "55");
     }
@@ -67,7 +67,7 @@ public class LoveMonsterClientTest {
         verify(mockAsyncHttpClient).get(eq("http://love.snc1/api/v1/loves"), requestParamsCaptor.capture(), any(JsonHttpResponseHandler.class));
 
         final Map<String, String> requestParams = parseParams(requestParamsCaptor.getValue());
-        assertEquals("should set client id param", requestParams.get("clientId"), "androidclient");
+        assertEquals("should set client id param", requestParams.get("clientId"), "androidapp");
         assertEquals("should set page param", requestParams.get("page"), "77");
         assertFalse("should not set user_id param", requestParams.containsKey("user_id"));
     }

--- a/app/src/test/java/org/ometa/lovemonster/service/LoveMonsterClientTest.java
+++ b/app/src/test/java/org/ometa/lovemonster/service/LoveMonsterClientTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -44,7 +45,21 @@ public class LoveMonsterClientTest {
     }
 
     @Test
-    public void testRetrieveRecentLoves_CreatesCorrectRequest() {
+    public void testRetrieveRecentLoves_UserId_CreatesCorrectRequest() {
+        final ArgumentCaptor<RequestParams> requestParamsCaptor = ArgumentCaptor.forClass(RequestParams.class);
+
+        client.retrieveRecentLoves(mockResponseHandler, 77, 55);
+
+        verify(mockAsyncHttpClient).get(eq("http://love.snc1/api/v1/loves"), requestParamsCaptor.capture(), any(JsonHttpResponseHandler.class));
+
+        final Map<String, String> requestParams = parseParams(requestParamsCaptor.getValue());
+        assertEquals("should set client id param", requestParams.get("clientId"), "androidclient");
+        assertEquals("should set page param", requestParams.get("page"), "77");
+        assertEquals("should set user_id param", requestParams.get("user_id"), "55");
+    }
+
+    @Test
+    public void testRetrieveRecentLoves_NoUserId_CreatesCorrectRequest() {
         final ArgumentCaptor<RequestParams> requestParamsCaptor = ArgumentCaptor.forClass(RequestParams.class);
 
         client.retrieveRecentLoves(mockResponseHandler, 77);
@@ -54,6 +69,7 @@ public class LoveMonsterClientTest {
         final Map<String, String> requestParams = parseParams(requestParamsCaptor.getValue());
         assertEquals("should set client id param", requestParams.get("clientId"), "androidclient");
         assertEquals("should set page param", requestParams.get("page"), "77");
+        assertFalse("should not set user_id param", requestParams.containsKey("user_id"));
     }
 
     @Test

--- a/app/src/test/java/org/ometa/lovemonster/service/LoveMonsterClientTest.java
+++ b/app/src/test/java/org/ometa/lovemonster/service/LoveMonsterClientTest.java
@@ -47,7 +47,7 @@ public class LoveMonsterClientTest {
     public void testRetrieveRecentLoves_CreatesCorrectRequest() {
         final ArgumentCaptor<RequestParams> requestParamsCaptor = ArgumentCaptor.forClass(RequestParams.class);
 
-        client.retrieveRecentLoves(77, mockResponseHandler);
+        client.retrieveRecentLoves(mockResponseHandler, 77);
 
         verify(mockAsyncHttpClient).get(eq("http://love.snc1/api/v1/loves"), requestParamsCaptor.capture(), any(JsonHttpResponseHandler.class));
 
@@ -60,7 +60,7 @@ public class LoveMonsterClientTest {
     public void testRetrieveRecentLoves_AsyncHttpThrowsException_InvokesOnFail() {
         doThrow(new RuntimeException()).when(mockAsyncHttpClient).get(anyString(), any(RequestParams.class), any(JsonHttpResponseHandler.class));
 
-        client.retrieveRecentLoves(1, mockResponseHandler);
+        client.retrieveRecentLoves(mockResponseHandler, 1);
 
         verify(mockResponseHandler).onFail();
     }
@@ -69,7 +69,7 @@ public class LoveMonsterClientTest {
     public void testRetrieveRecentLoves_RequestFails_InvokesOnFail() {
         final ArgumentCaptor<JsonHttpResponseHandler> jsonHttpResponseHandlerArgumentCaptor = ArgumentCaptor.forClass(JsonHttpResponseHandler.class);
 
-        client.retrieveRecentLoves(1, mockResponseHandler);
+        client.retrieveRecentLoves(mockResponseHandler, 1);
         verify(mockAsyncHttpClient).get(anyString(), any(RequestParams.class), jsonHttpResponseHandlerArgumentCaptor.capture());
         jsonHttpResponseHandlerArgumentCaptor.getValue().onFailure(500, null, null, new JSONObject());
 
@@ -83,7 +83,7 @@ public class LoveMonsterClientTest {
         final JSONObject expectedJsonObject = new JSONObject("{\"pages\":7}");
         when(mockResponseParser.parseLoveList(expectedJsonObject)).thenReturn(expectedLoves);
 
-        client.retrieveRecentLoves(1, mockResponseHandler);
+        client.retrieveRecentLoves(mockResponseHandler, 1);
         verify(mockAsyncHttpClient).get(anyString(), any(RequestParams.class), jsonHttpResponseHandlerArgumentCaptor.capture());
         jsonHttpResponseHandlerArgumentCaptor.getValue().onSuccess(200, null, expectedJsonObject);
 
@@ -97,7 +97,7 @@ public class LoveMonsterClientTest {
         final JSONObject expectedJsonObject = new JSONObject();
         when(mockResponseParser.parseLoveList(expectedJsonObject)).thenReturn(expectedLoves);
 
-        client.retrieveRecentLoves(1, mockResponseHandler);
+        client.retrieveRecentLoves(mockResponseHandler, 1);
         verify(mockAsyncHttpClient).get(anyString(), any(RequestParams.class), jsonHttpResponseHandlerArgumentCaptor.capture());
         jsonHttpResponseHandlerArgumentCaptor.getValue().onSuccess(200, null, expectedJsonObject);
 
@@ -109,7 +109,7 @@ public class LoveMonsterClientTest {
         final ArgumentCaptor<JsonHttpResponseHandler> jsonHttpResponseHandlerArgumentCaptor = ArgumentCaptor.forClass(JsonHttpResponseHandler.class);
         final List<Love> expectedLoves = new ArrayList<>();
 
-        client.retrieveRecentLoves(1, mockResponseHandler);
+        client.retrieveRecentLoves(mockResponseHandler, 1);
         verify(mockAsyncHttpClient).get(anyString(), any(RequestParams.class), jsonHttpResponseHandlerArgumentCaptor.capture());
         jsonHttpResponseHandlerArgumentCaptor.getValue().onSuccess(200, null, (JSONObject) null);
 

--- a/app/src/test/java/org/ometa/lovemonster/service/LoveMonsterClientTest.java
+++ b/app/src/test/java/org/ometa/lovemonster/service/LoveMonsterClientTest.java
@@ -1,0 +1,113 @@
+package org.ometa.lovemonster.service;
+
+import com.loopj.android.http.AsyncHttpClient;
+import com.loopj.android.http.JsonHttpResponseHandler;
+import com.loopj.android.http.RequestParams;
+
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.ometa.lovemonster.models.Love;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LoveMonsterClientTest {
+
+    @Mock
+    AsyncHttpClient mockAsyncHttpClient;
+    @Mock
+    ResponseParser mockResponseParser;
+    @Mock
+    LoveMonsterClient.LoveListResponseHandler mockResponseHandler;
+
+    LoveMonsterClient client;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        client = new LoveMonsterClient(mockResponseParser, mockAsyncHttpClient);
+    }
+
+    @Test
+    public void testRetrieveRecentLoves_CreatesCorrectRequest() {
+        final ArgumentCaptor<RequestParams> requestParamsCaptor = ArgumentCaptor.forClass(RequestParams.class);
+
+        client.retrieveRecentLoves(77, mockResponseHandler);
+
+        verify(mockAsyncHttpClient).get(eq("http://love.snc1/api/v1/loves"), requestParamsCaptor.capture(), any(JsonHttpResponseHandler.class));
+
+        final Map<String, String> requestParams = parseParams(requestParamsCaptor.getValue());
+        assertEquals("should set client id param", requestParams.get("clientId"), "androidclient");
+        assertEquals("should set page param", requestParams.get("page"), "77");
+    }
+
+    @Test
+    public void testRetrieveRecentLoves_AsyncHttpThrowsException_InvokesOnFail() {
+        doThrow(new RuntimeException()).when(mockAsyncHttpClient).get(anyString(), any(RequestParams.class), any(JsonHttpResponseHandler.class));
+
+        client.retrieveRecentLoves(1, mockResponseHandler);
+
+        verify(mockResponseHandler).onFail();
+    }
+
+    @Test
+    public void testRetrieveRecentLoves_RequestFails_InvokesOnFail() {
+        final ArgumentCaptor<JsonHttpResponseHandler> jsonHttpResponseHandlerArgumentCaptor = ArgumentCaptor.forClass(JsonHttpResponseHandler.class);
+
+        client.retrieveRecentLoves(1, mockResponseHandler);
+        verify(mockAsyncHttpClient).get(anyString(), any(RequestParams.class), jsonHttpResponseHandlerArgumentCaptor.capture());
+        jsonHttpResponseHandlerArgumentCaptor.getValue().onFailure(500, null, null, new JSONObject());
+
+        verify(mockResponseHandler).onFail();
+    }
+
+    @Test
+    public void testRetrieveRecentLoves_RequestSucceeds_InvokesOnSuccess() {
+        final ArgumentCaptor<JsonHttpResponseHandler> jsonHttpResponseHandlerArgumentCaptor = ArgumentCaptor.forClass(JsonHttpResponseHandler.class);
+        final List<Love> expectedLoves = new ArrayList<>();
+        final JSONObject expectedJsonObject = new JSONObject();
+        when(mockResponseParser.parseLoveList(expectedJsonObject)).thenReturn(expectedLoves);
+
+        client.retrieveRecentLoves(1, mockResponseHandler);
+        verify(mockAsyncHttpClient).get(anyString(), any(RequestParams.class), jsonHttpResponseHandlerArgumentCaptor.capture());
+        jsonHttpResponseHandlerArgumentCaptor.getValue().onSuccess(200, null, expectedJsonObject);
+
+        verify(mockResponseHandler).onSuccess(expectedLoves);
+    }
+
+    /**
+     * Parses the request params and returns a map of <param, value>.
+     * This is to work around an issue with RequestParams not exposing the parameters in an
+     * order-independent way.
+     *
+     * @param params
+     *      the params to parse
+     * @return
+     *      the map of param name to value
+     */
+    private Map<String, String> parseParams(final RequestParams params) {
+        final String paramString = params.toString();
+        final Map<String, String> parsedParams = new HashMap<>();
+
+        for (final String keyValuePair : paramString.split("&")) {
+            final String[] splitKeyValuePair = keyValuePair.split("=");
+            parsedParams.put(splitKeyValuePair[0], splitKeyValuePair[1]);
+        }
+
+        return parsedParams;
+    }
+}

--- a/app/src/test/java/org/ometa/lovemonster/service/LoveMonsterClientTest.java
+++ b/app/src/test/java/org/ometa/lovemonster/service/LoveMonsterClientTest.java
@@ -53,9 +53,9 @@ public class LoveMonsterClientTest {
         verify(mockAsyncHttpClient).get(eq("http://love.snc1/api/v1/loves"), requestParamsCaptor.capture(), any(JsonHttpResponseHandler.class));
 
         final Map<String, String> requestParams = parseParams(requestParamsCaptor.getValue());
-        assertEquals("should set client id param", requestParams.get("clientId"), "androidapp");
-        assertEquals("should set page param", requestParams.get("page"), "77");
-        assertEquals("should set user_id param", requestParams.get("user_id"), "55");
+        assertEquals("should set client id param", "androidapp", requestParams.get("clientId"));
+        assertEquals("should set page param", "77", requestParams.get("page"));
+        assertEquals("should set user_id param", "55", requestParams.get("user_id"));
     }
 
     @Test
@@ -67,8 +67,8 @@ public class LoveMonsterClientTest {
         verify(mockAsyncHttpClient).get(eq("http://love.snc1/api/v1/loves"), requestParamsCaptor.capture(), any(JsonHttpResponseHandler.class));
 
         final Map<String, String> requestParams = parseParams(requestParamsCaptor.getValue());
-        assertEquals("should set client id param", requestParams.get("clientId"), "androidapp");
-        assertEquals("should set page param", requestParams.get("page"), "77");
+        assertEquals("should set client id param", "androidapp", requestParams.get("clientId"));
+        assertEquals("should set page param", "77", requestParams.get("page"));
         assertFalse("should not set user_id param", requestParams.containsKey("user_id"));
     }
 


### PR DESCRIPTION
Supports pagination and also returns the total pages (for infinite scrolling).

For recent loves:

``` java
        int currentPage = ...;

        LoveMonsterClient.getInstance().retrieveRecentLoves(new LoveMonsterClient.LoveListResponseHandler() {
            @Override
            public void onSuccess(List<Love> loves, int totalPages) {
                // add the loves to the list, and kill infinite scrolling if we hit the max pages
            }

            @Override
            public void onFail() {
                // notify the user the request failed
            }
        }, currentPage);
```

For retrieving user specific loves:

``` java
LoveMonsterClient.getInstance().retrieveRecentLoves( ... , currentPage, userId);
```

EDIT: This is built off the existing api which returns a `pages` field at the top level of the response.  The new api endpoint has a breaking API change to how pages are represented (`meta.total_pages`), but this will degrade to 0 total pages until we align everything.
